### PR TITLE
Fixed a problem that reply destination is not set correctly when using SMTP

### DIFF
--- a/objects/sendEmail.json.php
+++ b/objects/sendEmail.json.php
@@ -14,6 +14,7 @@ if ($valid) {
     //var_dump($mail->SMTPAuth, $mail);
     //Set who the message is to be sent from
     $mail->setFrom($_POST['email'], $_POST['first_name']);
+    $mail->addReplyTo($_POST['email'], $_POST['first_name']);
     //Set who the message is to be sent to
     $mail->addAddress($config->getContactEmail());
     //Set the subject line


### PR DESCRIPTION
By using the addReplyTo option of PHPMailer, it is now possible to reply easily even when using SMTP.